### PR TITLE
Addressing Failed Tests

### DIFF
--- a/instrument/factories/ARCSDetPackCSVParser.py
+++ b/instrument/factories/ARCSDetPackCSVParser.py
@@ -62,7 +62,7 @@ def readConf( conffn ):
         continue
 
     #sort by packID
-    records.sort( lambda x,y: x[0]-y[0] )
+    records.sort(key=lambda x: x[0])
 
     return records
 

--- a/instrument/geometry/yaml/__init__.py
+++ b/instrument/geometry/yaml/__init__.py
@@ -6,7 +6,7 @@
 import yaml
 
 def parse_file(path):
-    d = yaml.load(open(path))
+    d = yaml.load(open(path), Loader=yaml.Loader) 
     from .parser import Parser
     parser = Parser()
     return parser.parse(d)


### PR DESCRIPTION
    1. Test 10: instrument/instrument/factories/ARCSBootstrap_TestCase
        ◦ Cause: Incorrect use of the sort() method.
        ◦ Solution: Change records.sort(lambda x, y: x[0] - y[0]) to records.sort(key=lambda x: x[0]).
    2. Test 20 & 21: instrument/instrument/geometry/yaml/parser_TestCase & renderer_TestCase
        ◦ Cause: Missing Loader argument in yaml.load() function.
        ◦ Solution: Update to use yaml.load(open(path)) for Python 3 compatibility.